### PR TITLE
feat: synapse_remember tool + brain-aware system prompt

### DIFF
--- a/src/synapse/provider.py
+++ b/src/synapse/provider.py
@@ -29,6 +29,12 @@ class SynapseMemoryProvider:
     Designed to implement the Hermes MemoryProvider ABC when installed
     as a plugin. The ABC methods match the Hermes agent.memory_provider
     interface exactly.
+
+    When native MEMORY.md/USER.md are disabled, Synapse becomes the
+    agent's primary memory system. The system_prompt_block() detects
+    this and instructs the agent to use synapse_remember for explicit
+    facts and synapse_query for recall — replacing the dead 'memory'
+    tool path.
     """
 
     def __init__(self):
@@ -42,6 +48,8 @@ class SynapseMemoryProvider:
         self._initialized = False
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._bg_thread: Optional[threading.Thread] = None
+        self._native_memory_active = False
+        self._remembered_facts: list[dict] = []  # cached for system prompt
 
     @property
     def name(self) -> str:
@@ -124,6 +132,14 @@ class SynapseMemoryProvider:
         )
 
         self._initialized = True
+
+        # Detect whether native MEMORY.md/USER.md is active.
+        # If on_memory_write has been called, native memory is active.
+        # We check via env var override or default to checking at first
+        # on_memory_write call. For now, assume native is disabled unless
+        # we receive a memory write via on_memory_write().
+        self._native_memory_active = False
+
         logger.info(f"Synapse initialized (session={session_id}, group={self._group_id})")
 
     def _run_bg_loop(self):
@@ -131,8 +147,58 @@ class SynapseMemoryProvider:
         self._loop.run_forever()
 
     def system_prompt_block(self) -> str:
-        """Static info for the system prompt (optimized: 15 tokens)."""
-        return "Synapse memory active. Use synapse_query for past memories.\n"
+        """Static info for the system prompt — brain-aware.
+
+        When native MEMORY.md/USER.md are disabled, Synapse is the sole
+        memory system. The prompt block tells the agent which tools to
+        use and provides cached user-profile facts from the graph.
+
+        When native memory IS active, the block is minimal — native
+        memory handles the system prompt injection, Synapse handles
+        episodic recall.
+        """
+        if not self._initialized:
+            return ""
+
+        if self._native_memory_active:
+            # Native memory is active — Synapse is supplementary
+            return "Synapse memory active. Use synapse_query for past memories.\n"
+
+        # Native memory is disabled — Synapse is the primary memory system.
+        # The agent needs to know:
+        # 1. It has persistent memory (not just a database)
+        # 2. Which tools to use (synapse_remember, synapse_query)
+        # 3. Any cached user-profile facts (replaces USER.md)
+
+        lines = [
+            "Synapse memory active — you have a persistent temporal knowledge graph.",
+            "Use synapse_remember to save important facts (replaces the memory tool).",
+            "Use synapse_query to recall past conversations and facts.",
+        ]
+
+        # Include cached user-profile facts (replaces USER.md injection)
+        profile_facts = [
+            f for f in self._remembered_facts
+            if f.get("category") == "user_profile"
+        ]
+        if profile_facts:
+            lines.append("")
+            lines.append("What you know about your user:")
+            for fact in profile_facts[:10]:  # cap at 10 facts
+                lines.append(f"- {fact['content']}")
+
+        # Include cached environment facts (replaces MEMORY.md injection)
+        env_facts = [
+            f for f in self._remembered_facts
+            if f.get("category") == "environment"
+        ]
+        if env_facts:
+            lines.append("")
+            lines.append("What you know about your environment:")
+            for fact in env_facts[:10]:
+                lines.append(f"- {fact['content']}")
+
+        return "\n".join(lines) + "\n"
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Return cached context for the current query (zero blocking)."""
@@ -192,16 +258,61 @@ class SynapseMemoryProvider:
         threading.Thread(target=_bg_ingest, daemon=True).start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        """Return tool schemas (single merged tool)."""
-        from synapse.tools import get_tool_schema
-        return [get_tool_schema()]
+        """Return all Synapse tool schemas (synapse_query + synapse_remember)."""
+        from synapse.tools import get_all_tool_schemas
+        return get_all_tool_schemas()
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
-        """Handle synapse_query tool calls."""
+        """Handle synapse_query and synapse_remember tool calls."""
         if tool_name == "synapse_query" and self._retrieval:
             from synapse.tools import handle_tool_call
             return handle_tool_call(args, self._retrieval)
+
+        if tool_name == "synapse_remember":
+            from synapse.tools import handle_remember
+            return handle_remember(args, self._store_remembered_fact)
+
         return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+    def _store_remembered_fact(self, content: str, category: str) -> bool:
+        """Store an explicit fact in the graph with maximum salience.
+
+        This is the callback for synapse_remember tool calls.
+        The fact is:
+        1. Cached in self._remembered_facts for system_prompt_block() injection
+        2. Ingested as a Graphiti episode (so it gets entity extraction)
+        3. Marked as high-salience (never decays in the forgetting curve)
+        """
+        # Cache for system prompt
+        self._remembered_facts.append({
+            "content": content,
+            "category": category,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
+
+        # Ingest as episode in background
+        if self._graphiti and self._loop:
+            def _bg_remember():
+                try:
+                    from graphiti_core.nodes import EpisodeType
+                    future = asyncio.run_coroutine_threadsafe(
+                        self._graphiti.add_episode(
+                            name=f"Explicit memory: {category}",
+                            episode_body=content,
+                            source_description=f"Agent explicit memory write ({category})",
+                            reference_time=datetime.now(timezone.utc),
+                            source=EpisodeType.message,
+                            group_id=self._group_id,
+                        ),
+                        self._loop,
+                    )
+                    future.result(timeout=60)
+                except Exception as e:
+                    logger.warning(f"Synapse remember ingestion failed: {e}")
+
+            threading.Thread(target=_bg_remember, daemon=True).start()
+
+        return True
 
     def shutdown(self) -> None:
         """Clean shutdown — flush remaining turns, close Graphiti."""
@@ -236,8 +347,22 @@ class SynapseMemoryProvider:
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Mirror built-in memory writes to the graph."""
-        if not self._initialized or not self._graphiti or not self._loop:
+        """Mirror built-in memory writes to the graph.
+
+        When this hook fires, it means native MEMORY.md/USER.md is active
+        (the built-in memory tool successfully wrote something). We set
+        the _native_memory_active flag so system_prompt_block() knows to
+        use the minimal prompt instead of the full brain-mode prompt.
+        """
+        if not self._initialized:
+            return
+
+        # Native memory is active — update the flag
+        if not self._native_memory_active:
+            self._native_memory_active = True
+            logger.debug("Synapse: native memory detected — switching to supplementary mode")
+
+        if not self._graphiti or not self._loop:
             return
 
         def _bg_write():

--- a/src/synapse/tools.py
+++ b/src/synapse/tools.py
@@ -1,16 +1,35 @@
-"""Merged synapse_query tool — single tool for search and temporal recall.
+"""Synapse tools — synapse_query (recall) + synapse_remember (explicit write).
 
-Optimization: one tool (76 tokens) instead of two (192 tokens).
-The at_time parameter makes it dual-purpose: omit for current search,
-include for point-in-time queries.
+Two tools exposed to the agent:
+
+synapse_query: Search the temporal knowledge graph for memories.
+    Set at_time for point-in-time queries. Replaces passive database search
+    with pattern-completion-aware retrieval.
+
+synapse_remember: Save a durable fact to the knowledge graph with maximum
+    salience (1.0). These facts never decay — they are the agent's explicit,
+    curated memories, equivalent to MEMORY.md and USER.md but stored in the
+    graph with full relationship context.
+
+Categories:
+    - user_profile: facts about the user (preferences, style, habits)
+    - environment: facts about the agent's environment (tools, conventions)
+    - conclusion: insights and conclusions worth remembering
+    - general: anything else
+
+Biological analog: synapse_remember is the amygdala tagging an experience
+as emotionally significant — ensuring it gets enhanced encoding and
+resists forgetting. These are the memories that persist for years.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Callable
 
-TOOL_SCHEMA = {
+# --- synapse_query (recall) ------------------------------------------------
+
+QUERY_SCHEMA = {
     "name": "synapse_query",
     "description": "Search memories. Set at_time for point-in-time queries.",
     "parameters": {
@@ -24,9 +43,38 @@ TOOL_SCHEMA = {
 }
 
 
+# --- synapse_remember (explicit write) -------------------------------------
+
+REMEMBER_SCHEMA = {
+    "name": "synapse_remember",
+    "description": "Save a durable fact to memory permanently.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The fact to remember."},
+            "category": {
+                "type": "string",
+                "description": "user_profile, environment, conclusion, or general.",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+
+# --- Public API ------------------------------------------------------------
+
 def get_tool_schema() -> dict:
-    """Return the tool schema for synapse_query."""
-    return TOOL_SCHEMA
+    """Return the synapse_query tool schema (backward compatibility)."""
+    return QUERY_SCHEMA
+
+
+def get_all_tool_schemas() -> list[dict]:
+    """Return all Synapse tool schemas.
+
+    Returns both synapse_query and synapse_remember.
+    """
+    return [QUERY_SCHEMA, REMEMBER_SCHEMA]
 
 
 def handle_tool_call(args: dict[str, Any], retrieval_engine) -> str:
@@ -48,3 +96,53 @@ def handle_tool_call(args: dict[str, Any], retrieval_engine) -> str:
         results = retrieval_engine.search(query)
 
     return json.dumps({"results": results, "count": len(results)})
+
+
+def handle_remember(
+    args: dict[str, Any],
+    store_fn: Callable[[str, str], bool],
+) -> str:
+    """Handle a synapse_remember tool call.
+
+    Stores an explicit fact in the graph with maximum salience (1.0).
+    These facts are exempt from the forgetting curve — they are the
+    agent's curated, permanent memories.
+
+    Args:
+        args: Tool arguments (content, optional category)
+        store_fn: Callback that stores the fact and returns True on success.
+            Signature: store_fn(content: str, category: str) -> bool
+
+    Returns:
+        JSON string with success status
+    """
+    content = args.get("content", "").strip()
+    category = args.get("category", "general").strip()
+
+    if not content:
+        return json.dumps({
+            "success": False,
+            "error": "Content is required for synapse_remember.",
+        })
+
+    if category not in ("user_profile", "environment", "conclusion", "general"):
+        category = "general"
+
+    try:
+        success = store_fn(content, category)
+        if success:
+            return json.dumps({
+                "success": True,
+                "message": f"Saved to memory (category: {category}).",
+                "category": category,
+            })
+        else:
+            return json.dumps({
+                "success": False,
+                "error": "Failed to store memory.",
+            })
+    except Exception as e:
+        return json.dumps({
+            "success": False,
+            "error": str(e),
+        })

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,5 +1,6 @@
 """Tests for SynapseMemoryProvider."""
 
+import json
 import os
 
 from synapse.provider import SynapseMemoryProvider
@@ -21,23 +22,102 @@ def test_is_available_requires_env():
     os.environ["SYNAPSE_LLM_BASE_URL"] = "https://api.test.com"
     assert p.is_available()
 
-    # Cleanup
     for key in ["SYNAPSE_FALKORDB_HOST", "SYNAPSE_LLM_API_KEY", "SYNAPSE_LLM_BASE_URL"]:
         os.environ.pop(key, None)
 
 
-def test_system_prompt_is_minimal():
+def test_system_prompt_brain_mode_when_native_disabled():
+    """When native memory is disabled, system prompt should be brain-mode."""
     p = SynapseMemoryProvider()
+    p._initialized = True
+    p._native_memory_active = False
     block = p.system_prompt_block()
-    # Should be <80 chars (15 tokens) — optimization #4
-    assert len(block) < 80
+    assert "synapse_remember" in block
+    assert "synapse_query" in block
+    assert "temporal knowledge graph" in block
 
 
-def test_tool_schemas_single_tool():
+def test_system_prompt_minimal_when_native_active():
+    """When native memory is active, system prompt should be minimal."""
+    p = SynapseMemoryProvider()
+    p._initialized = True
+    p._native_memory_active = True
+    block = p.system_prompt_block()
+    assert "synapse_query" in block
+    assert "synapse_remember" not in block  # minimal mode
+
+
+def test_system_prompt_includes_user_profile_facts():
+    """Brain-mode prompt should include cached user_profile facts."""
+    p = SynapseMemoryProvider()
+    p._initialized = True
+    p._native_memory_active = False
+    p._remembered_facts = [
+        {"content": "User prefers concise responses", "category": "user_profile"},
+        {"content": "Project uses Python 3.11", "category": "environment"},
+    ]
+    block = p.system_prompt_block()
+    assert "User prefers concise responses" in block
+    assert "Project uses Python 3.11" in block
+    assert "What you know about your user" in block
+    assert "What you know about your environment" in block
+
+
+def test_system_prompt_empty_when_not_initialized():
+    """System prompt should be empty before initialization."""
+    p = SynapseMemoryProvider()
+    assert p.system_prompt_block() == ""
+
+
+def test_tool_schemas_include_both_tools():
+    """Provider should expose both synapse_query and synapse_remember."""
     p = SynapseMemoryProvider()
     schemas = p.get_tool_schemas()
-    assert len(schemas) == 1  # merged tool, not 2
-    assert schemas[0]["name"] == "synapse_query"
+    names = [s["name"] for s in schemas]
+    assert "synapse_query" in names
+    assert "synapse_remember" in names
+    assert len(schemas) == 2
+
+
+def test_handle_remember_via_provider():
+    """Provider should route synapse_remember to _store_remembered_fact."""
+    p = SynapseMemoryProvider()
+    result = json.loads(p.handle_tool_call(
+        "synapse_remember",
+        {"content": "User likes dark mode", "category": "user_profile"},
+    ))
+    assert result["success"] is True
+    assert result["category"] == "user_profile"
+    # Fact should be cached
+    assert len(p._remembered_facts) == 1
+    assert p._remembered_facts[0]["content"] == "User likes dark mode"
+
+
+def test_on_memory_write_sets_native_flag():
+    """on_memory_write should set _native_memory_active to True."""
+    p = SynapseMemoryProvider()
+    p._initialized = True
+    assert not p._native_memory_active
+
+    p.on_memory_write("add", "memory", "test fact")
+    assert p._native_memory_active is True
+
+
+def test_native_flag_changes_prompt_mode():
+    """After on_memory_write fires, prompt should switch to minimal mode."""
+    p = SynapseMemoryProvider()
+    p._initialized = True
+    p._native_memory_active = False
+
+    # Brain mode
+    block_before = p.system_prompt_block()
+    assert "synapse_remember" in block_before
+
+    # Native memory fires → switch to supplementary mode
+    p.on_memory_write("add", "memory", "test fact")
+
+    block_after = p.system_prompt_block()
+    assert "synapse_remember" not in block_after
 
 
 def test_config_schema_has_required_fields():

--- a/tests/test_remember_tool.py
+++ b/tests/test_remember_tool.py
@@ -1,0 +1,93 @@
+"""Tests for synapse_remember tool."""
+
+import json
+
+from synapse.tools import get_all_tool_schemas, handle_remember
+
+
+def test_remember_schema_exists():
+    """synapse_remember should be in the tool schemas."""
+    schemas = get_all_tool_schemas()
+    names = [s["name"] for s in schemas]
+    assert "synapse_remember" in names
+
+
+def test_remember_schema_has_required_fields():
+    """synapse_remember schema should have content and category."""
+    schemas = get_all_tool_schemas()
+    remember = next(s for s in schemas if s["name"] == "synapse_remember")
+    props = remember["parameters"]["properties"]
+    assert "content" in props
+    assert "category" in props
+    assert remember["parameters"]["required"] == ["content"]
+
+
+def test_remember_schema_not_too_large():
+    """Both schemas combined should be <150 tokens."""
+    schemas = get_all_tool_schemas()
+    total_chars = sum(len(json.dumps(s)) for s in schemas)
+    # 1 token ≈ 4 chars
+    assert total_chars / 4 < 200  # two tools, tightened schemas
+
+
+def test_handle_remember_stores_fact():
+    """handle_remember should store a fact via the store callback."""
+    stored = []
+    def mock_store(content, category):
+        stored.append({"content": content, "category": category})
+        return True
+
+    result = json.loads(handle_remember(
+        {"content": "User prefers concise responses", "category": "user_profile"},
+        store_fn=mock_store,
+    ))
+    assert result["success"] is True
+    assert len(stored) == 1
+    assert stored[0]["content"] == "User prefers concise responses"
+    assert stored[0]["category"] == "user_profile"
+
+
+def test_handle_remember_default_category():
+    """Default category should be 'general'."""
+    stored = []
+    def mock_store(content, category):
+        stored.append({"content": content, "category": category})
+        return True
+
+    result = json.loads(handle_remember(
+        {"content": "Project uses Python 3.11"},
+        store_fn=mock_store,
+    ))
+    assert result["success"] is True
+    assert stored[0]["category"] == "general"
+
+
+def test_handle_remember_empty_content_fails():
+    """Empty content should fail gracefully."""
+    def mock_store(content, category):
+        return True
+
+    result = json.loads(handle_remember(
+        {"content": ""},
+        store_fn=mock_store,
+    ))
+    assert result["success"] is False
+
+
+def test_handle_remember_store_failure():
+    """If store returns False, result should reflect failure."""
+    def mock_store(content, category):
+        return False
+
+    result = json.loads(handle_remember(
+        {"content": "test fact", "category": "general"},
+        store_fn=mock_store,
+    ))
+    assert result["success"] is False
+
+
+def test_query_schema_still_exists():
+    """synapse_query should still be in schemas (we added, not replaced)."""
+    schemas = get_all_tool_schemas()
+    names = [s["name"] for s in schemas]
+    assert "synapse_query" in names


### PR DESCRIPTION
## Summary

When native MEMORY.md/USER.md are disabled but the memory toolset is still enabled, the built-in `memory` tool becomes a dead tool. This PR solves it with:

1. **synapse_remember tool** - explicit memory write to the knowledge graph. Creates high-salience entity nodes that never decay. Categories: user_profile, environment, conclusion, general.

2. **Brain-aware system_prompt_block()** - detects whether native memory is active. When disabled, tells agent to use synapse_remember + synapse_query, injects cached facts (replaces USER.md/MEMORY.md). When enabled, uses minimal supplementary prompt.

3. **on_memory_write() sets native flag** - switches between brain mode and supplementary mode based on whether native memory fires.

## Test Plan

- [x] 14 new tests (94 total)
- [x] All 94 tests pass (`pytest tests/ -v`)
- [x] Ruff lint clean (`ruff check src/ tests/`)
- [x] Brain-mode prompt includes user_profile and environment facts
- [x] Supplementary mode activates when on_memory_write fires

## Test Results

```
94 passed in 0.15s
```