### PR TITLE
fix: use dynamic CI badge and correct pre-PyPI install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Temporal knowledge graph memory that doesn't just *store* — it *remembers*.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-94%20passing-brightgreen.svg)](https://github.com/ardhaecosystem/synapse/actions)
-[![CI](https://img.shields.io/badge/CI-passing-brightgreen.svg)](https://github.com/ardhaecosystem/synapse/actions)
+[![CI](https://github.com/ardhaecosystem/synapse/actions/workflows/ci.yml/badge.svg)](https://github.com/ardhaecosystem/synapse/actions/workflows/ci.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-ff69b4.svg)](https://github.com/ardhaecosystem/synapse/blob/main/CONTRIBUTING.md)
 
 </div>
@@ -47,7 +46,7 @@ Three commands. That's it.
 docker run -d --name falkordb -p 6379:6379 falkordb/falkordb:latest
 
 # 2. Install Synapse
-pip install synapse-memory
+pip install "git+https://github.com/ardhaecosystem/synapse.git"
 
 # 3. Configure Hermes
 hermes config set memory.provider synapse

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -52,10 +52,10 @@ docker exec synapse-falkordb redis-cli PING
 ### Step 2: Install Synapse
 
 ```bash
-# From PyPI (when published)
-pip install synapse-memory
+# From source (PyPI publication coming soon)
+pip install "git+https://github.com/ardhaecosystem/synapse.git"
 
-# Or from source
+# Or clone and install in editable mode
 git clone https://github.com/ardhaecosystem/synapse.git
 cd synapse
 pip install -e .


### PR DESCRIPTION
## Summary

- Replace static test/CI shields with dynamic GitHub Actions badge that auto-reflects actual CI status
  - Removed `tests-94 passing` and `CI-passing` hardcoded shields
  - Added dynamic `![CI](https://github.com/ardhaecosystem/synapse/actions/workflows/ci.yml/badge.svg)`
- Fix `pip install synapse-memory` to install from git (package not yet on PyPI)
  - Updated in both README.md quick start and docs/user-guide.md install section

## Why

Static badges lie — they say "94 passing" even if CI is red. New users following the quick start would hit `ERROR: No matching distribution found for synapse-memory` and bounce.

## Test Plan

- [ ] CI passes on this PR (validates the dynamic badge works)
- [ ] Verify install command works: `pip install "git+https://github.com/ardhaecosystem/synapse.git"`