### PR TITLE
chore: remove deprecated docker-compose version key

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   falkordb:
     image: falkordb/falkordb:latest


### PR DESCRIPTION
## Summary

- Remove deprecated `version: "3.8"` from `docker/docker-compose.yml`

## Why

The `version` field is deprecated in Docker Compose v2+. Compose now auto-detects the schema version, and keeping the field triggers a deprecation warning on every `docker compose up` call.

## Test Plan

- [ ] CI passes (no code changes, only compose file metadata)