### PR TITLE
docs: add star CTA near top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Temporal knowledge graph memory that doesn't just *store* — it *remembers*.
 
 </div>
 
+<p align="center">
+  <strong>Self-hosted temporal memory for AI agents.</strong><br>
+  If this project is useful to you, consider <a href="https://github.com/ardhaecosystem/synapse">⭐ starring the repo</a> — it helps others discover it.
+</p>
+
 ---
 
 ## The Problem


### PR DESCRIPTION
## Summary

- Add a subtle star CTA after the hero section, before "The Problem"
- Most visitors never scroll past the first screen — the existing star CTA is at the very bottom of a 333-line README

## Why

Stars are the primary discovery signal on GitHub. The only existing CTA is at line 330. Adding a non-intrusive reminder near the top catches the majority of visitors who don't read the whole README.

## Test Plan

- [ ] Verify README renders correctly on GitHub (align=center, proper formatting)
