### PR TITLE
fix: guard tool calls before init, add save_config, declare plugin hooks (#16)

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,3 +5,6 @@ pip_dependencies:
   - graphiti-core[falkordb]
 requires_env:
   - SYNAPSE_FALKORDB_HOST
+hooks:
+  - on_session_end
+  - on_memory_write

--- a/src/synapse/provider.py
+++ b/src/synapse/provider.py
@@ -18,6 +18,7 @@ import logging
 import os
 import threading
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -258,12 +259,26 @@ class SynapseMemoryProvider:
         threading.Thread(target=_bg_ingest, daemon=True).start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        """Return all Synapse tool schemas (synapse_query + synapse_remember)."""
+        """Return all Synapse tool schemas (synapse_query + synapse_remember).
+
+        Tool schemas are static module-level constants in tools.py — they
+        do not depend on Graphiti/FalkorDB being initialized. Hermes calls
+        this method at registration time, before initialize(), so we must
+        return schemas unconditionally.
+        """
         from synapse.tools import get_all_tool_schemas
         return get_all_tool_schemas()
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
         """Handle synapse_query and synapse_remember tool calls."""
+        if not self._initialized:
+            return json.dumps({
+                "error": (
+                    f"Cannot handle '{tool_name}' — Synapse is not initialized. "
+                    "Ensure FalkorDB is running and SYNAPSE_* env vars are set."
+                ),
+            })
+
         if tool_name == "synapse_query" and self._retrieval:
             from synapse.tools import handle_tool_call
             return handle_tool_call(args, self._retrieval)
@@ -409,6 +424,22 @@ class SynapseMemoryProvider:
             {"key": "half_life_days", "description": "Forgetting curve half-life in days",
              "required": False, "env_var": "SYNAPSE_HALF_LIFE_DAYS", "default": "7.0"},
         ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Write non-secret config to ~/.hermes/synapse.json.
+
+        Secret fields (falkordb_password, llm_api_key) are handled by
+        Hermes via the env_var route — they go to .env automatically.
+        This method persists the remaining non-secret fields.
+        """
+        config_path = Path(hermes_home) / "synapse.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        non_secret = {
+            k: v for k, v in values.items()
+            if k not in ("falkordb_password", "llm_api_key")
+        }
+        config_path.write_text(json.dumps(non_secret, indent=2))
 
     def backup_paths(self) -> List[str]:
         """No external paths — FalkorDB data is in Docker."""

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -79,9 +79,51 @@ def test_tool_schemas_include_both_tools():
     assert len(schemas) == 2
 
 
+def test_tool_schemas_available_before_initialize():
+    """get_tool_schemas() must return schemas before initialize() is called.
+
+    Hermes calls get_tool_schemas() at registration time, before
+    initialize(). Schemas are static constants and must not depend
+    on instance state. (Issue #16)
+    """
+    p = SynapseMemoryProvider()
+    assert not p._initialized
+    schemas = p.get_tool_schemas()
+    assert len(schemas) == 2
+    names = [s["name"] for s in schemas]
+    assert "synapse_query" in names
+    assert "synapse_remember" in names
+
+
+def test_handle_tool_call_before_init_returns_error():
+    """handle_tool_call before initialize() should return a clear error.
+
+    Should NOT return 'Unknown tool' — the tool name is valid, just not
+    ready yet. (Issue #16)
+    """
+    p = SynapseMemoryProvider()
+    assert not p._initialized
+
+    # synapse_query before init
+    result = json.loads(p.handle_tool_call("synapse_query", {"query": "test"}))
+    assert "error" in result
+    assert "not initialized" in result["error"]
+    assert "Unknown tool" not in result["error"]
+
+    # synapse_remember before init
+    result = json.loads(p.handle_tool_call(
+        "synapse_remember",
+        {"content": "test fact", "category": "general"},
+    ))
+    assert "error" in result
+    assert "not initialized" in result["error"]
+    assert "Unknown tool" not in result["error"]
+
+
 def test_handle_remember_via_provider():
     """Provider should route synapse_remember to _store_remembered_fact."""
     p = SynapseMemoryProvider()
+    p._initialized = True
     result = json.loads(p.handle_tool_call(
         "synapse_remember",
         {"content": "User likes dark mode", "category": "user_profile"},
@@ -134,3 +176,28 @@ def test_backup_paths_empty():
     """FalkorDB data is in Docker — no external paths to declare."""
     p = SynapseMemoryProvider()
     assert p.backup_paths() == []
+
+
+def test_save_config_writes_non_secret_fields(tmp_path):
+    """save_config should write non-secret fields to synapse.json."""
+    p = SynapseMemoryProvider()
+    p.save_config(
+        {
+            "falkordb_host": "localhost",
+            "falkordb_port": 6379,
+            "llm_api_key": "secret-key",
+            "falkordb_password": "secret-pw",
+            "llm_model": "gpt-4o-mini",
+        },
+        hermes_home=str(tmp_path),
+    )
+    config_path = tmp_path / "synapse.json"
+    assert config_path.exists()
+    data = json.loads(config_path.read_text())
+    # Non-secret fields are persisted
+    assert data["falkordb_host"] == "localhost"
+    assert data["falkordb_port"] == 6379
+    assert data["llm_model"] == "gpt-4o-mini"
+    # Secret fields are NOT written to the JSON file
+    assert "llm_api_key" not in data
+    assert "falkordb_password" not in data


### PR DESCRIPTION
## Summary

Fixes #16 — `get_tool_schemas()` returns 0 tools when Hermes calls before `initialize()`.

### Root Cause

The reporter's plugin wrapper delegated `get_tool_schemas()` to `self._instance` which was `None` pre-init. Synapse's own `get_tool_schemas()` already returned static schemas directly, but two related bugs were uncovered while tracing:

1. **`handle_tool_call` fell through to "Unknown tool" when called before `initialize()`** — `synapse_query` was silently dropped because `self._retrieval` is `None` pre-init, and `synapse_remember` fell through too. The tool names are valid, just not ready yet.
2. **Missing `save_config()` method** — Hermes MemoryProvider ABC requires it for `hermes memory setup`, but Synapse didn't implement it.
3. **`plugin.yaml` missing `hooks` field** — docs declare it as part of the spec.

### Changes

| File | Change |
|------|--------|
| `provider.py` | Added `_initialized` guard in `handle_tool_call` returning a clear error |
| `provider.py` | Added `save_config()` writing non-secret fields to `synapse.json` |
| `provider.py` | Clarified `get_tool_schemas()` docstring — static schemas, no init dependency |
| `plugin.yaml` | Added `hooks: [on_session_end, on_memory_write]` |
| `test_provider.py` | 3 new tests (pre-init schemas, pre-init tool call error, save_config) |

### Test Results

- **97 passed** in 0.28s (was 94, +3 new tests)
- `ruff check src/ tests/` — all checks passed

Closes #16