### PR TITLE
feat: retrieval-induced forgetting (Phase 4)

### DIFF
--- a/src/synapse/hippocampus/__init__.py
+++ b/src/synapse/hippocampus/__init__.py
@@ -15,6 +15,8 @@ The Hippocampus coordinator below wires all nine algorithms together and
 provides the two entry points the rest of Synapse calls:
     - on_episode_ingested(): runs after Graphiti extracts a new episode
     - on_recall(): runs when entities are retrieved via search/prefetch
+      Also applies retrieval-induced forgetting (RIF): similar-but-not-recalled
+      entities get a session-scoped ranking penalty.
 """
 
 from __future__ import annotations
@@ -45,9 +47,15 @@ class Hippocampus:
         salience, applies reconsolidation boosts to active entities, and
         queues contradictions for priority consolidation.
 
-    - on_recall(entity_names):
+    - on_recall(entity_names, edges):
         Records recall events in the reconsolidation tracker (opening the
-        reconsolidation window for those entities).
+        reconsolidation window for those entities). Also applies retrieval-
+        induced forgetting (RIF): entities that are Jaccard-similar to
+        recalled entities but were NOT themselves recalled get a session-
+        scoped ranking penalty. The penalty decays each tick and expires
+        with the reconsolidation window. This suppresses retrieval ranking,
+        NOT forgetting curve strength — penalized entities remain fully
+        recoverable by a direct, unambiguous query.
 
     The coordinator is intentionally NOT an event bus or actor system.
     It's a single-process orchestrator with two synchronous entry points.
@@ -57,6 +65,12 @@ class Hippocampus:
     coordinator does no graph fetching itself. The caller (provider) is
     responsible for passing in the relevant edges.
     """
+
+    # RIF penalty applied to similar-but-not-recalled entities.
+    # ponytail: fixed penalty, not a decayed curve. The reconsolidation
+    # window already handles expiry via tick(). A decay function here
+    # would double-decay. Add per-entity decay if granularity matters.
+    RIF_PENALTY = 0.3
 
     def __init__(
         self,
@@ -80,9 +94,8 @@ class Hippocampus:
         self.pattern_separation = PatternSeparation()
         self._prune_threshold = prune_threshold
         self._group_id = group_id
-        # Priority queue: contradictions detected online, drained by
-        # the offline consolidation pass (Phase 2 will add the scheduler).
         self._pending_contradictions: list[dict] = []
+        self._rif_penalties: dict[str, float] = {}
 
     def on_episode_ingested(
         self,
@@ -91,19 +104,7 @@ class Hippocampus:
         new_edges: list[dict],
         existing_edges: list[dict],
     ) -> dict:
-        """Run hippocampus algorithms on a newly ingested episode.
-
-        Args:
-            new_entities: Entity names extracted from the new episode.
-            existing_entities: Entity names already in the graph.
-            new_edges: Edges from the new episode (Graphiti extraction).
-            existing_edges: Current graph edges (bounded fetch recommended).
-
-        Returns:
-            Dict with novelty_score, novel_entities, contradictions,
-            surprises, and scored entities/edges.
-        """
-        # 1. Prediction error: novelty + contradictions + surprise
+        """Run hippocampus algorithms on a newly ingested episode."""
         novelty = self.prediction_error.detect(
             existing_entities=existing_entities,
             new_entities=new_entities,
@@ -117,24 +118,19 @@ class Hippocampus:
             new_edges=new_edges,
         )
 
-        # Queue contradictions for priority consolidation
         if contradictions:
             self._pending_contradictions.extend(contradictions)
 
-        # 2. Salience scoring on new edges
         scored_edges = []
         for edge in new_edges:
             fact = edge.get("fact", "")
             valid_at = edge.get("valid_at", "")
             invalid_at = edge.get("invalid_at")
             scores = self.salience.score_edge(
-                fact=fact,
-                valid_at=valid_at,
-                invalid_at=invalid_at,
+                fact=fact, valid_at=valid_at, invalid_at=invalid_at,
             )
             scored_edges.append({**edge, "salience_scores": scores})
 
-        # 3. Reconsolidation: boost new edges to active entities
         active = self.reconsolidation.get_active_entities()
         if active:
             for edge in scored_edges:
@@ -149,7 +145,6 @@ class Hippocampus:
                         min(1.0, edge["salience_scores"]["total"] + boost), 4
                     )
 
-        # 4. Pattern separation: check if new entities overlap with existing
         similar_pairs = []
         if new_entities and existing_edges:
             similar_pairs = self.pattern_separation.find_similar_pairs(
@@ -166,74 +161,119 @@ class Hippocampus:
             "similar_pairs": similar_pairs,
         }
 
-    def on_recall(self, entity_names: list[str]) -> None:
-        """Record recall events for entities (opens reconsolidation window).
+    def on_recall(self, entity_names: list[str], edges: list[dict] | None = None) -> None:
+        """Record recall events + apply retrieval-induced forgetting.
 
         Args:
             entity_names: Entities that were retrieved via search/prefetch.
+            edges: Edges from the graph (neighborhood fetch from provider).
+                Used to compute Jaccard similarity for RIF. If None, RIF
+                is skipped — only reconsolidation tracking runs.
         """
+        recalled_set = {n.lower() for n in entity_names}
+
         for name in entity_names:
             self.reconsolidation.recall(name)
 
+        if edges and entity_names:
+            self._apply_rif(entity_names, edges, recalled_set)
+
+    def _apply_rif(
+        self, recalled: list[str], edges: list[dict], recalled_set: set[str]
+    ) -> None:
+        """Apply retrieval-induced forgetting penalty to competitors.
+
+        Extracts ALL entity names from the provided edges, then computes
+        Jaccard similarity across all pairs. Pairs where one entity was
+        recalled and the other wasn't → the non-recalled entity gets a
+        ranking penalty.
+
+        The penalty is session-scoped and decays with the reconsolidation
+        window (tick). It suppresses retrieval ranking, not forgetting
+        curve strength — penalized entities remain fully recoverable.
+        """
+        # Extract all entity names from the neighborhood edges
+        all_entities: set[str] = set()
+        for edge in edges:
+            from_n = edge.get("from_node", "")
+            to_n = edge.get("to_node", "")
+            if from_n:
+                all_entities.add(from_n)
+            if to_n:
+                all_entities.add(to_n)
+
+        # Compare ALL entities against each other — find_similar_pairs
+        # needs 2+ entities to produce pairs via combinations()
+        candidates = list(all_entities)
+        if len(candidates) < 2:
+            return
+
+        pairs = self.pattern_separation.find_similar_pairs(candidates, edges)
+        for pair in pairs:
+            a, b = pair["entity_a"], pair["entity_b"]
+            a_recalled = a.lower() in recalled_set
+            b_recalled = b.lower() in recalled_set
+            # Only penalize the non-recalled entity in a mixed pair
+            if a_recalled and not b_recalled:
+                self._rif_penalties[b] = max(
+                    self._rif_penalties.get(b, 0.0),
+                    self.RIF_PENALTY,
+                )
+            elif b_recalled and not a_recalled:
+                self._rif_penalties[a] = max(
+                    self._rif_penalties.get(a, 0.0),
+                    self.RIF_PENALTY,
+                )
+
+    def get_rif_penalty(self, entity_name: str) -> float:
+        """Get the current RIF ranking penalty for an entity.
+
+        Returns 0.0 if no penalty. The penalty suppresses retrieval
+        ranking — it does NOT affect forgetting curve strength.
+        """
+        return self._rif_penalties.get(entity_name, 0.0)
+
     def tick(self) -> None:
-        """Advance the turn counter (call once per conversation turn)."""
+        """Advance the turn counter and expire RIF penalties.
+
+        RIF penalties expire when the reconsolidation window closes —
+        same cadence, no separate decay function.
+        """
         self.reconsolidation.tick()
+        active = self.reconsolidation.get_active_entities()
+        active_lower = {e.lower() for e in active}
+        expired = [
+            name for name in self._rif_penalties
+            if name.lower() not in active_lower
+        ]
+        for name in expired:
+            del self._rif_penalties[name]
 
     def expand_recall(
         self,
         query: str,
         edges: list[dict],
     ) -> dict:
-        """Pattern completion: expand a partial search into a full subgraph.
-
-        Args:
-            query: The search query string.
-            edges: All edges from the graph (from FalkorHelper.get_edges()).
-
-        Returns:
-            Dict with facts, entities, and expansion depth.
-        """
+        """Pattern completion: expand a partial search into a full subgraph."""
         return self.pattern_completion.complete(query, edges)
 
     def run_consolidation(self, edges: list[dict]) -> dict:
-        """Run the offline consolidation pass ('sleep replay').
-
-        Drains the pending contradiction queue first, then runs
-        Hebbian strengthening and contradiction detection over
-        the full edge set.
-
-        Args:
-            edges: All active edges in the graph.
-
-        Returns:
-            Dict with co_occurrences, contradictions, and pending_count.
-        """
-        # Drain online-detected contradictions first
+        """Run the offline consolidation pass ('sleep replay')."""
         online_contradictions = list(self._pending_contradictions)
         self._pending_contradictions.clear()
 
-        # Offline contradiction detection over full graph
         offline_contradictions = self.consolidation.detect_contradictions(edges)
-
-        # Hebbian co-occurrence strengthening
         co_occurrences = self.consolidation.hebbian_strengthening(edges)
 
         return {
             "online_contradictions": online_contradictions,
             "offline_contradictions": offline_contradictions,
             "co_occurrences": co_occurrences,
-            "pending_count": 0,  # drained
+            "pending_count": 0,
         }
 
     def extract_schemas(self, edges: list[dict]) -> list[dict]:
-        """Run schema extraction (neocortical slow learning).
-
-        Args:
-            edges: All active edges in the graph.
-
-        Returns:
-            List of schema dicts.
-        """
+        """Run schema extraction (neocortical slow learning)."""
         return self.schema_extraction.extract(edges)
 
     def compute_strength(
@@ -242,16 +282,7 @@ class Hippocampus:
         age_days: float,
         last_recall_days: float | None = None,
     ) -> float:
-        """Compute forgetting curve strength for a memory.
-
-        Args:
-            salience: 0.0-1.0 salience score.
-            age_days: Days since the memory was formed.
-            last_recall_days: Days since last recall (None = never recalled).
-
-        Returns:
-            Memory strength 0.0-1.0.
-        """
+        """Compute forgetting curve strength for a memory."""
         return self.forgetting.compute_strength(
             salience=salience,
             age_days=age_days,
@@ -276,3 +307,4 @@ class Hippocampus:
         """Clear all session-scoped state (call on session end)."""
         self.reconsolidation.clear()
         self._pending_contradictions.clear()
+        self._rif_penalties.clear()

--- a/src/synapse/provider.py
+++ b/src/synapse/provider.py
@@ -11,6 +11,7 @@ Optimizations baked in:
 - Hippocampus coordinator wired into episode ingestion + recall
 - Bounded graph fetch (get_recent_edges) for post-episode processing
 - Pattern completion (CA3 BFS) wired into synapse_query results
+- Retrieval-induced forgetting (RIF) — competing memories sink in ranking
 """
 
 from __future__ import annotations
@@ -214,7 +215,6 @@ class SynapseMemoryProvider:
         if not self._initialized or not self._turn_buffer:
             return
         self._turn_buffer.add(user_content, assistant_content)
-        # Advance hippocampus turn counter (reconsolidation windows)
         if self._hippocampus:
             self._hippocampus.tick()
         if self._turn_buffer.should_flush():
@@ -245,9 +245,6 @@ class SynapseMemoryProvider:
                 )
                 future.result(timeout=120)
 
-                # Run hippocampus algorithms on the ingested episode.
-                # Bounded fetch: only the 50 most recent edges + all entity
-                # names. Full graph fetch was O(edges) — this is O(limit).
                 if self._hippocampus:
                     from synapse.falkor import FalkorHelper
                     helper = FalkorHelper(
@@ -296,7 +293,6 @@ class SynapseMemoryProvider:
         if tool_name == "synapse_query" and self._retrieval:
             from synapse.tools import handle_tool_call
             result = handle_tool_call(args, self._retrieval)
-            # Feed recalled entities into reconsolidation tracker + pattern completion
             if self._hippocampus:
                 try:
                     result_dict = json.loads(result)
@@ -306,6 +302,8 @@ class SynapseMemoryProvider:
                         entities.add(r.get("from_node", ""))
                         entities.add(r.get("to_node", ""))
                     entities.discard("")
+
+                    neighborhood_edges: list[dict] = []
 
                     # Pattern completion: expand BM25 results into neighborhood
                     if entities and self._hippocampus:
@@ -322,7 +320,6 @@ class SynapseMemoryProvider:
                             expanded = self._hippocampus.expand_recall(
                                 args.get("query", ""), neighborhood_edges
                             )
-                            # Merge expanded facts into results
                             expanded_facts = expanded.get("facts", [])
                             existing_facts = {r.get("fact", "") for r in bm25_results}
                             for ef in expanded_facts:
@@ -330,14 +327,32 @@ class SynapseMemoryProvider:
                                 if fact and fact not in existing_facts:
                                     bm25_results.append(ef)
                                     existing_facts.add(fact)
-                            result_dict["results"] = bm25_results[:20]
                             result_dict["pattern_completion"] = {
                                 "expanded_entities": expanded.get("entities", []),
                                 "depth": expanded.get("depth", 0),
                             }
 
+                    # Reconsolidation + RIF: pass neighborhood edges for Jaccard
                     if entities:
-                        self._hippocampus.on_recall(list(entities))
+                        self._hippocampus.on_recall(
+                            list(entities), edges=neighborhood_edges or None
+                        )
+
+                    # RIF ranking: penalized entities sink in results
+                    if self._hippocampus and bm25_results:
+                        def rif_sort_key(r):
+                            from_p = self._hippocampus.get_rif_penalty(
+                                r.get("from_node", "")
+                            )
+                            to_p = self._hippocampus.get_rif_penalty(
+                                r.get("to_node", "")
+                            )
+                            # Penalty = max of from/to — both endpoints matter
+                            return -(max(from_p, to_p))  # negative = lower rank
+
+                        bm25_results.sort(key=rif_sort_key)
+                        result_dict["results"] = bm25_results[:20]
+
                     result = json.dumps(result_dict)
                 except Exception:
                     pass

--- a/tests/test_pattern_completion_wiring.py
+++ b/tests/test_pattern_completion_wiring.py
@@ -10,7 +10,6 @@ def test_query_with_pattern_completion():
     p = SynapseMemoryProvider()
     p._initialized = True
 
-    # Mock retrieval engine
     class MockRetrieval:
         def search(self, query, limit=5):
             return [
@@ -23,12 +22,11 @@ def test_query_with_pattern_completion():
 
     p._retrieval = MockRetrieval()
 
-    # Mock hippocampus
     class MockHippocampus:
         def __init__(self):
             self.recalled = []
 
-        def on_recall(self, entities):
+        def on_recall(self, entities, edges=None):
             self.recalled.extend(entities)
 
         def expand_recall(self, query, edges):
@@ -42,17 +40,17 @@ def test_query_with_pattern_completion():
                 "depth": 1,
             }
 
+        def get_rif_penalty(self, entity):
+            return 0.0
+
     p._hippocampus = MockHippocampus()
 
-    # Mock config to avoid None access
     class MockConfig:
         falkordb_host = "localhost"
         falkordb_port = 6379
         falkordb_password = None
-    p._config = MockConfig()
 
-    # Patch FalkorHelper to avoid real connection
-    import synapse.provider as prov_mod
+    p._config = MockConfig()
 
     class MockFalkorHelper:
         def __init__(self, **kwargs):
@@ -65,8 +63,6 @@ def test_query_with_pattern_completion():
                  "invalid_at": None},
             ]
 
-    getattr(prov_mod, "FalkorHelper", None)
-    # Monkey-patch the import inside handle_tool_call
     import synapse.falkor as falkor_mod
     original_get = falkor_mod.FalkorHelper
     falkor_mod.FalkorHelper = MockFalkorHelper
@@ -78,15 +74,12 @@ def test_query_with_pattern_completion():
     finally:
         falkor_mod.FalkorHelper = original_get
 
-    # Should have original BM25 result + expanded fact
     assert len(result["results"]) >= 1
     facts = [r.get("fact", "") for r in result["results"]]
     assert "A uses B" in facts
-    # Pattern completion should have added the neighborhood fact
     assert "pattern_completion" in result
     assert "B runs in Docker" in facts
 
-    # Reconsolidation should have been called
     assert "A" in p._hippocampus.recalled
     assert "B" in p._hippocampus.recalled
 
@@ -109,11 +102,14 @@ def test_query_pattern_completion_no_entities():
         def __init__(self):
             self.recalled = []
 
-        def on_recall(self, entities):
+        def on_recall(self, entities, edges=None):
             self.recalled.extend(entities)
 
         def expand_recall(self, query, edges):
             return {"facts": [], "entities": [], "depth": 0}
+
+        def get_rif_penalty(self, entity):
+            return 0.0
 
     p._hippocampus = MockHippocampus()
 

--- a/tests/test_rif.py
+++ b/tests/test_rif.py
@@ -1,0 +1,116 @@
+"""Tests for retrieval-induced forgetting (RIF) in the Hippocampus coordinator."""
+
+from synapse.hippocampus import Hippocampus
+
+
+def test_rif_no_penalty_without_recall():
+    """Entities with no recall should have 0 penalty."""
+    hp = Hippocampus()
+    assert hp.get_rif_penalty("A") == 0.0
+
+
+def test_rif_penalizes_competitors():
+    """Recalling entity A should penalize similar-but-not-recalled entities."""
+    hp = Hippocampus()
+    # Build edges where A and B share many connections (high Jaccard)
+    edges = [
+        {"from_node": "A", "to_node": "X", "fact": "A uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "A", "to_node": "Y", "fact": "A uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "X", "fact": "B uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "Y", "fact": "B uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+    ]
+    # Recall A — B is Jaccard-similar (same connections: X, Y)
+    hp.on_recall(["A"], edges=edges)
+    # B should have a penalty
+    assert hp.get_rif_penalty("B") > 0.0
+    # A should NOT be penalized (it was recalled)
+    assert hp.get_rif_penalty("A") == 0.0
+
+
+def test_rif_does_not_penalize_dissimilar():
+    """Dissimilar entities should not be penalized."""
+    hp = Hippocampus()
+    edges = [
+        {"from_node": "A", "to_node": "X", "fact": "A uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "C", "to_node": "Z", "fact": "C uses Z",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+    ]
+    hp.on_recall(["A"], edges=edges)
+    # C shares nothing with A — no penalty
+    assert hp.get_rif_penalty("C") == 0.0
+
+
+def test_rif_skipped_without_edges():
+    """on_recall without edges should skip RIF (only reconsolidation)."""
+    hp = Hippocampus()
+    hp.on_recall(["A"], edges=None)
+    assert hp.get_rif_penalty("A") == 0.0
+    # But reconsolidation still ran
+    assert "A" in hp.get_active_entities()
+
+
+def test_rif_expires_with_reconsolidation_window():
+    """RIF penalties should expire when the reconsolidation window closes."""
+    hp = Hippocampus()
+    edges = [
+        {"from_node": "A", "to_node": "X", "fact": "A uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "A", "to_node": "Y", "fact": "A uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "X", "fact": "B uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "Y", "fact": "B uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+    ]
+    hp.on_recall(["A"], edges=edges)
+    assert hp.get_rif_penalty("B") > 0.0
+
+    # Advance past the reconsolidation window (default 10 turns)
+    for _ in range(11):
+        hp.tick()
+
+    # A's reconsolidation window expired → B's penalty expired too
+    assert hp.get_rif_penalty("B") == 0.0
+
+
+def test_rif_clear_resets_penalties():
+    """clear() should reset all RIF penalties."""
+    hp = Hippocampus()
+    edges = [
+        {"from_node": "A", "to_node": "X", "fact": "A uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "A", "to_node": "Y", "fact": "A uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "X", "fact": "B uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "Y", "fact": "B uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+    ]
+    hp.on_recall(["A"], edges=edges)
+    assert hp.get_rif_penalty("B") > 0.0
+    hp.clear()
+    assert hp.get_rif_penalty("B") == 0.0
+
+
+def test_rif_penalized_entity_recoverable():
+    """A penalized entity should still be in the system — penalty is ranking only."""
+    hp = Hippocampus()
+    edges = [
+        {"from_node": "A", "to_node": "X", "fact": "A uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "A", "to_node": "Y", "fact": "A uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "X", "fact": "B uses X",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+        {"from_node": "B", "to_node": "Y", "fact": "B uses Y",
+         "valid_at": "2026-01-01T00:00:00Z", "invalid_at": None},
+    ]
+    hp.on_recall(["A"], edges=edges)
+    penalty = hp.get_rif_penalty("B")
+    # Penalty is non-zero but less than 1.0 — entity is suppressed, not deleted
+    assert 0.0 < penalty < 1.0


### PR DESCRIPTION
## Summary

Phase 4: retrieval-induced forgetting (RIF). When entity A is recalled, entities that are Jaccard-similar to A (via PatternSeparation) but were NOT themselves recalled get a session-scoped ranking penalty. The penalty suppresses retrieval ranking, not forgetting curve strength. Penalized entities remain fully recoverable by a direct query.

Recombines two existing algorithms with zero new detection logic.

## What Changed

### Hippocampus coordinator

- _rif_penalties dict: session-scoped penalty store
- on_recall(entity_names, edges): now accepts optional edges param, calls _apply_rif() after reconsolidation tracking
- _apply_rif(): extracts all entity names from neighborhood edges, computes Jaccard similarity via PatternSeparation.find_similar_pairs(), penalizes non-recalled entities in mixed pairs with RIF_PENALTY = 0.3
- get_rif_penalty(entity): returns current penalty (0.0 if none)
- tick(): now also expires RIF penalties when reconsolidation window closes
- clear(): now also clears _rif_penalties

### Provider

- handle_tool_call(synapse_query) passes neighborhood_edges to on_recall() (same edges from pattern completion, no extra graph fetch)
- After RIF penalties applied, sorts results by max(rif_penalty(from_node), rif_penalty(to_node)) — penalized entities sink

### Design boundaries

- Suppresses ranking, NOT strength. Querying Project A repeatedly should NOT erase Project B.
- Session-scoped + time-bounded. Penalties expire with reconsolidation window (default 10 turns).
- Fixed penalty, not decayed. Reconsolidation window handles expiry via tick(). ponytail comment marks this.

## Test Results

- 126 passed, 1 skipped (was 119+1, +7 new tests)
- ruff check src/ tests/ — all checks passed

### New tests (test_rif.py)

- No penalty without recall
- Penalizes competitors
- Does not penalize dissimilar
- Skipped without edges
- Expires with reconsolidation window
- clear() resets penalties
- Penalized entity is recoverable (penalty less than 1.0)