### PR TITLE
chore: cleanup debug artifacts + gitignore graphify-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 
 # FalkorDB
 falkordb-data/
+
+# Graphify (regenerated locally, not needed in repo)
+graphify-out/


### PR DESCRIPTION
Cleanup after Phases 1-4.

- Deleted debug artifacts: `_debug.py`, `ARCHITECTURE_DISCUSSION.md`, and 4 stray `.py` files in `graphify-out/`
- Added `graphify-out/` to `.gitignore` (regenerated locally, not needed in repo)
- Updated graphify graph: 727 nodes, 847 edges, 52 communities (was 445 nodes, 552 edges, 29 communities — reflects all Phase 1-4 code changes)

No code changes — housekeeping only.