### PR TITLE
fix: use OpenAIGenericClient for non-OpenAI LLM backend compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,5 @@
+"""Shim for Hermes' memory-provider loader (expects __init__.py at the
+plugin root, not under src/). The real provider lives in src/synapse/provider.py.
+MemoryProvider
+"""
+from synapse.provider import register  # noqa: F401

--- a/src/synapse/provider.py
+++ b/src/synapse/provider.py
@@ -103,9 +103,10 @@ class SynapseMemoryProvider:
         )
         self._graphiti = Graphiti(
             graph_driver=self._driver,
-            # ponytail: json_object works on all OpenAI-compatible endpoints (DeepSeek,
-            # OpenRouter, vLLM, etc.); json_schema only works on api.openai.com + constrained-decoding servers.
-            # Add a SYNAPSE_STRUCTURED_OUTPUT_MODE env var if a user needs json_schema on vLLM/llama.cpp.
+            # ponytail: json_object works on all OpenAI-compatible endpoints
+            # (DeepSeek, OpenRouter, vLLM, etc.); json_schema only works on
+            # api.openai.com + constrained-decoding servers.
+            # Add SYNAPSE_STRUCTURED_OUTPUT_MODE env var if user needs json_schema.
             llm_client=OpenAIGenericClient(config=llm_config, structured_output_mode='json_object'),
             embedder=OpenAIEmbedder(config=OpenAIEmbedderConfig(
                 api_key=self._config.llm_api_key,

--- a/src/synapse/provider.py
+++ b/src/synapse/provider.py
@@ -87,7 +87,7 @@ class SynapseMemoryProvider:
         from graphiti_core.driver.falkordb_driver import FalkorDriver
         from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
         from graphiti_core.llm_client.config import LLMConfig
-        from graphiti_core.llm_client.openai_client import OpenAIClient
+        from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
 
         self._driver = FalkorDriver(
             host=self._config.falkordb_host,
@@ -103,7 +103,10 @@ class SynapseMemoryProvider:
         )
         self._graphiti = Graphiti(
             graph_driver=self._driver,
-            llm_client=OpenAIClient(config=llm_config),
+            # ponytail: json_object works on all OpenAI-compatible endpoints (DeepSeek,
+            # OpenRouter, vLLM, etc.); json_schema only works on api.openai.com + constrained-decoding servers.
+            # Add a SYNAPSE_STRUCTURED_OUTPUT_MODE env var if a user needs json_schema on vLLM/llama.cpp.
+            llm_client=OpenAIGenericClient(config=llm_config, structured_output_mode='json_object'),
             embedder=OpenAIEmbedder(config=OpenAIEmbedderConfig(
                 api_key=self._config.llm_api_key,
                 base_url=self._config.llm_base_url,


### PR DESCRIPTION
## Summary

Fixes three bugs from #26 — all rooted in `OpenAIClient` being hardcoded for OpenAI-proper.

### Bug 1: Responses API breaks non-OpenAI endpoints

`provider.py` hardcoded `OpenAIClient`, which calls `client.responses.parse()` → `POST /v1/responses`. That endpoint only exists on `api.openai.com`. Every non-OpenAI `SYNAPSE_LLM_BASE_URL` target (DeepSeek, OpenRouter, vLLM, self-hosted) gets 404 on every entity/episode extraction call. `synapse_remember` reports `success: true` but nothing lands in FalkorDB — silent failure.

**Fix:** Swap to `OpenAIGenericClient` which uses `chat.completions.create()` exclusively. Graphiti's own maintainers recommend this for any non-OpenAI backend.

### Bug 2: DeepSeek rejects `json_schema` response_format

`OpenAIGenericClient` defaults to `structured_output_mode='json_schema'`. DeepSeek rejects this with `"This response_format type is unavailable now"`. 

**Fix:** Pass `structured_output_mode='json_object'` explicitly. Schema gets injected into the prompt instead of enforced natively — Graphiti's built-in fallback path.

> `ponytail:` `json_object` is the safe default for broad compatibility. If a user runs vLLM/llama.cpp with constrained decoding and wants stricter `json_schema` enforcement, an env var (`SYNAPSE_STRUCTURED_OUTPUT_MODE`) would be the upgrade path.

### Bug 3: Plugin `src/` layout breaks Hermes memory-provider discovery

Hermes' plugin loader scans for `__init__.py` at the plugin root and text-searches for `register_memory_provider` or `MemoryProvider`. Synapse only has `src/synapse/__init__.py` (which has neither). `hermes plugins install` silently succeeds but the plugin is completely inert.

**Fix:** Add root-level `__init__.py` shim that re-exports `register` from `src/synapse/provider.py`.

## Test Plan

- [x] All 126 unit tests pass (`.venv/bin/python -m pytest tests/`)
- [x] 1 pre-existing skip (FalkorDB integration test, unrelated)
- [x] Verified `OpenAIGenericClient` constructor signature against installed `graphiti-core` package
- [x] Verified root `__init__.py` shim imports cleanly: `from synapse.provider import register`

Closes #26